### PR TITLE
Move the binary instead of renaming it

### DIFF
--- a/scripts/tool_installation.sh
+++ b/scripts/tool_installation.sh
@@ -45,7 +45,7 @@ cd $HOME
 cd solana-mission-control
 
 go build -o solana-mc
-mv solana-mc $HOME/go/bin
+mv solana-mc $HOME/go/bin/
 
 echo "--------checking for solana binary path and updates it in env--------"
 


### PR DESCRIPTION
With the script as it is now, solana-mc is renamed as bin, and not placed inside of $HOME/go/bin/ folder